### PR TITLE
Update DatabaseSchema.cs

### DIFF
--- a/Runtime/DatabaseSchema.cs
+++ b/Runtime/DatabaseSchema.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace BennyKok.NotionAPI
 {
-    [CreateAssetMenu(fileName = "DatabaseSchema", menuName = "Notion API/DatabaseSchema", order = 0)]
+    [CreateAssetMenu(fileName = "MyDatabaseSchema", menuName = "Notion API/DatabaseSchema", order = 0)]
     public class DatabaseSchema : ScriptableObject
     {
         public string apiKey;


### PR DESCRIPTION
Changed the default file name, because having the exact same name as the ScriptableAsset will cause problems later on when it auto-generates a class of the same name.